### PR TITLE
Handle filenames with filepath package

### DIFF
--- a/grafana/common.go
+++ b/grafana/common.go
@@ -1,7 +1,6 @@
 package grafana
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ func writeToFile(directory string, content []byte, name string, tag string) erro
 			return err
 		}
 	}
-	fileName = fmt.Sprintf("%s/%s.json", path, name)
+	fileName = filepath.Join(path, name+".json")
 	dashboardFile, err = os.Create(fileName)
 	if err != nil {
 		return err

--- a/grafana/dashboard.go
+++ b/grafana/dashboard.go
@@ -3,11 +3,10 @@ package grafana
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/grafana-tools/sdk"
 )
@@ -75,8 +74,8 @@ func PushDashboard(grafanaURL string, apiKey string, directory string, folderId 
 		return err
 	}
 	for _, file := range filesInDir {
-		if strings.HasSuffix(file.Name(), ".json") {
-			if rawBoard, err = ioutil.ReadFile(fmt.Sprintf("%s/%s", directory, file.Name())); err != nil {
+		if filepath.Ext(file.Name()) == ".json" {
+			if rawBoard, err = ioutil.ReadFile(filepath.Join(directory, file.Name())); err != nil {
 				log.Println(err)
 				ExecutionErrorHappened = true
 				continue

--- a/grafana/datasource.go
+++ b/grafana/datasource.go
@@ -3,11 +3,10 @@ package grafana
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/grafana-tools/sdk"
 )
@@ -57,8 +56,8 @@ func PushDatasources(grafanaURL string, apiKey string, directory string) error {
 		return err
 	}
 	for _, file := range filesInDir {
-		if strings.HasSuffix(file.Name(), ".json") {
-			if rawFolder, err = ioutil.ReadFile(fmt.Sprintf("%s/%s", directory, file.Name())); err != nil {
+		if filepath.Ext(file.Name()) == ".json" {
+			if rawFolder, err = ioutil.ReadFile(filepath.Join(directory, file.Name())); err != nil {
 				log.Println(err)
 				continue
 			}

--- a/grafana/folder.go
+++ b/grafana/folder.go
@@ -3,12 +3,11 @@ package grafana
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/grafana-tools/sdk"
 )
@@ -57,8 +56,8 @@ func PushFolder(grafanaURL string, apiKey string, directory string) error {
 		return err
 	}
 	for _, file := range filesInDir {
-		if strings.HasSuffix(file.Name(), ".json") {
-			if rawFolder, err = ioutil.ReadFile(fmt.Sprintf("%s/%s", directory, file.Name())); err != nil {
+		if filepath.Ext(file.Name()) == ".json" {
+			if rawFolder, err = ioutil.ReadFile(filepath.Join(directory, file.Name())); err != nil {
 				log.Println(err)
 				ExecutionErrorHappened = true
 				continue

--- a/grafana/notification.go
+++ b/grafana/notification.go
@@ -3,11 +3,10 @@ package grafana
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/grafana-tools/sdk"
 )
@@ -56,8 +55,8 @@ func PushNotification(grafanaURL string, apiKey string, directory string) error 
 		return err
 	}
 	for _, file := range filesInDir {
-		if strings.HasSuffix(file.Name(), ".json") {
-			if rawFolder, err = ioutil.ReadFile(fmt.Sprintf("%s/%s", directory, file.Name())); err != nil {
+		if filepath.Ext(file.Name()) == ".json" {
+			if rawFolder, err = ioutil.ReadFile(filepath.Join(directory, file.Name())); err != nil {
 				log.Println(err)
 				ExecutionErrorHappened = true
 				continue


### PR DESCRIPTION
The `filepath` package can handle filenames on all supported filesystems.
