### PR TITLE
feat: support custom http headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.json
 vendor
+.idea/

--- a/README.MD
+++ b/README.MD
@@ -99,6 +99,7 @@ grafana-sync push-datasources --apikey="eyJrIjoiOWJYTktGNFlCbFVMOG1LY3d6ekN4Mmw4
 `apikey` - Grafana api key, need to be editor or admin. Default `""`.  
 Api key can be stored in `$HOME/.grafana-sync.yaml` as `apikey: <ApiKey>`  
 `url` - Grafana Url with port. Default `http://localhost:3000`  
+`customHeaders` - Key-value pairs of custom http headers (header1=value1,header2=value2)  
 
 ## Contributing
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,14 +20,16 @@ import (
 	"log"
 	"os"
 
-	"github.com/mpostument/grafana-sync/grafana"
 	"github.com/spf13/cobra"
+
+	"github.com/mpostument/grafana-sync/grafana"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
 var cfgFile string
+var customHeaders map[string]string
 
 var rootCmd = &cobra.Command{
 	Use:     "grafana-sync",
@@ -222,6 +224,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("url", "u", "http://localhost:3000", "Grafana Url with port")
 	rootCmd.PersistentFlags().StringP("directory", "d", ".", "Directory where to save dashboards")
 	rootCmd.PersistentFlags().StringP("apikey", "a", "", "Grafana api key")
+	rootCmd.PersistentFlags().StringToStringVar(&customHeaders, "customHeaders", map[string]string{}, "Key-value pairs of custom http headers (key1=value1,key2=value2)")
 	pullDataSourcesCmd.PersistentFlags().StringP("tag", "t", "", "Dashboard tag to read")
 	pushDashboardsCmd.PersistentFlags().IntP("folderId", "f", 0, "Directory Id to which push dashboards")
 	pushDashboardsCmd.PersistentFlags().StringP("folderName", "n", "", "Directory name to which push dashboards")
@@ -230,6 +233,10 @@ func init() {
 	pullDashboardsCmd.PersistentFlags().StringP("tag", "t", "", "Dashboard tag to p")
 
 	if err := viper.BindPFlag("apikey", rootCmd.PersistentFlags().Lookup("apikey")); err != nil {
+		log.Println(err)
+	}
+
+	if err := viper.BindPFlag("customHeaders", rootCmd.PersistentFlags().Lookup("customHeaders")); err != nil {
 		log.Println(err)
 	}
 
@@ -267,4 +274,6 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
+
+	grafana.InitHttpClient(viper.GetStringMapString("customHeaders"))
 }

--- a/grafana/dashboard.go
+++ b/grafana/dashboard.go
@@ -20,7 +20,7 @@ func PullDashboard(grafanaURL string, apiKey string, directory string, tag strin
 	)
 
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func PushDashboard(grafanaURL string, apiKey string, directory string, folderId 
 	)
 
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}

--- a/grafana/datasource.go
+++ b/grafana/datasource.go
@@ -18,7 +18,7 @@ func PullDatasources(grafanaURL string, apiKey string, directory string) error {
 	)
 	ctx := context.Background()
 
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func PushDatasources(grafanaURL string, apiKey string, directory string) error {
 	)
 
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}

--- a/grafana/folder.go
+++ b/grafana/folder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -19,7 +18,7 @@ func PullFolders(grafanaURL string, apiKey string, directory string) error {
 	)
 	ctx := context.Background()
 
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,7 @@ func PushFolder(grafanaURL string, apiKey string, directory string) error {
 	)
 
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, http.DefaultClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func PushFolder(grafanaURL string, apiKey string, directory string) error {
 
 func FindFolderId(grafanaURL string, apiKey string, folderName string) (int, error) {
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return 0, err
 	}

--- a/grafana/http.go
+++ b/grafana/http.go
@@ -1,0 +1,28 @@
+package grafana
+
+import (
+	"net/http"
+
+	"github.com/grafana-tools/sdk"
+)
+
+var httpClient = sdk.DefaultHTTPClient
+
+type customHttpTransport struct {
+	http.Transport
+	customHeaders map[string]string
+}
+
+func (ct *customHttpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, value := range ct.customHeaders {
+		req.Header.Add(key, value)
+	}
+
+	return ct.Transport.RoundTrip(req)
+}
+
+func InitHttpClient(customHeaders map[string]string) {
+	httpClient.Transport = &customHttpTransport{
+		customHeaders: customHeaders,
+	}
+}

--- a/grafana/notification.go
+++ b/grafana/notification.go
@@ -18,7 +18,7 @@ func PullNotifications(grafanaURL string, apiKey string, directory string) error
 	)
 	ctx := context.Background()
 
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func PushNotification(grafanaURL string, apiKey string, directory string) error 
 	)
 
 	ctx := context.Background()
-	c, err := sdk.NewClient(grafanaURL, apiKey, sdk.DefaultHTTPClient)
+	c, err := sdk.NewClient(grafanaURL, apiKey, httpClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds support for settings custom HTTP headers during API interaction.

It can be used for environments that require additional authentication. Cloudflare Zero Trust, basic auth, etc.

Example:
`--customHeaders
"CF-Access-Client-Id=XXX.access,CF-Access-Client-Secret=YYY"`